### PR TITLE
chore: remove "enabled" from the settings file

### DIFF
--- a/LSP-css.sublime-commands
+++ b/LSP-css.sublime-commands
@@ -3,8 +3,8 @@
         "caption": "Preferences: LSP-css Settings",
         "command": "edit_settings",
         "args": {
-          "base_file": "${packages}/LSP-css/LSP-css.sublime-settings",
-          "default": "// Settings in here override those in \"LSP-css/LSP-css.sublime-settings\",\n\n{\n\t$0\n}\n"
-        }
+            "base_file": "${packages}/LSP-css/LSP-css.sublime-settings",
+            "default": "// Settings in here override those in \"LSP-css/LSP-css.sublime-settings\",\n\n{\n\t$0\n}\n",
+        },
     },
 ]

--- a/LSP-css.sublime-settings
+++ b/LSP-css.sublime-settings
@@ -1,5 +1,4 @@
 {
-	"enabled": true,
 	"languages": [
 		{
 			"languageId": "css",

--- a/vscode-css/compile-vscode-css-languageserver.sh
+++ b/vscode-css/compile-vscode-css-languageserver.sh
@@ -20,9 +20,7 @@ rm -rf \
 # or get the source via git clone
 # git clone --depth=1 https://github.com/vscode-langservers/vscode-css-languageserver "${SRC_DIR}"
 
-wget https://github.com/vscode-langservers/vscode-css-languageserver/archive/master.zip -O src.zip
-unzip src.zip
-rm -f src.zip
+curl -L https://github.com/vscode-langservers/vscode-css-languageserver/archive/master.tar.gz | tar -xzv
 mv vscode-css-languageserver-master "${SRC_DIR}"
 
 popd || exit


### PR DESCRIPTION
> Unrelated but you could also remove `"enabled": true` from `LSP-html.sublime-settings` since it's not really read from there (it's supposed to be handled by removing or disabling package instead).
> 
> Feel free to handle it separately though.

https://github.com/sublimelsp/LSP-html/pull/4#issuecomment-600469443