### PR TITLE
Fix: Use ${node_bin} for the node binary

### DIFF
--- a/LSP-css.sublime-settings
+++ b/LSP-css.sublime-settings
@@ -1,4 +1,5 @@
 {
+	"command": ["${node_bin}", "${server_path}", "--stdio"],
 	"languages": [
 		{
 			"languageId": "css",

--- a/plugin.py
+++ b/plugin.py
@@ -1,4 +1,3 @@
-from LSP.plugin.core.typing import Mapping, Any, Callable
 from lsp_utils import NpmClientHandler
 import os
 
@@ -15,14 +14,3 @@ class LspCssPlugin(NpmClientHandler):
     package_name = __package__
     server_directory = 'language-server'
     server_binary_path = os.path.join(server_directory, 'out', 'node', 'cssServerMain.js')
-
-    def on_pre_server_command(self, command: Mapping[str, Any], done_callback: Callable[[], None]) -> bool:
-        if command['command'] == 'editor.action.triggerSuggest':
-            session = self.weaksession()
-            if session:
-                view = session.window.active_view()
-                if view and view.is_valid():
-                    view.run_command("auto_complete")
-                    done_callback()
-                    return True
-        return False

--- a/plugin.py
+++ b/plugin.py
@@ -16,10 +16,6 @@ class LspCssPlugin(NpmClientHandler):
     server_directory = 'language-server'
     server_binary_path = os.path.join(server_directory, 'out', 'node', 'cssServerMain.js')
 
-    @classmethod
-    def install_in_cache(cls) -> bool:
-        return False
-
     def on_pre_server_command(self, command: Mapping[str, Any], done_callback: Callable[[], None]) -> bool:
         if command['command'] == 'editor.action.triggerSuggest':
             session = self.weaksession()


### PR DESCRIPTION
With the latest version of lsp_utils a change was introduced [1] that allows using a locally
managed node runtime instead of the system one. For that to work, the "node" command
needs to use a variable.

[1] https://github.com/sublimelsp/lsp_utils/commit/403345a0c5c15e84802c712044c630a9fb236b9d