### PR TITLE
chore: add hinting for disabled_capabilities for colorProvider

### DIFF
--- a/LSP-css.sublime-settings
+++ b/LSP-css.sublime-settings
@@ -30,6 +30,8 @@
 			],
 		},
 	],
+	// "disabled_capabilities" is ST4-only.
+	// If you are on ST3, it's in LSP's configuration and can't be set client-wise.
 	"disabled_capabilities": {
 		// remove the comment for "colorProvider" if you prefer other color plugins
 		// such as "ColorHelper" or "Color Highlighter"

--- a/LSP-css.sublime-settings
+++ b/LSP-css.sublime-settings
@@ -30,6 +30,11 @@
 			],
 		},
 	],
+	"disabled_capabilities": {
+		// remove the comment for "colorProvider" if you prefer other color plugins
+		// such as "ColorHelper" or "Color Highlighter"
+		// "colorProvider": true,
+	},
 	"initializationOptions": {
 		// @see https://github.com/sublimelsp/LSP-css/pull/2#discussion_r393881421
 		"dataPaths": [],


### PR DESCRIPTION
As of LSP `4070-1.2.12`, `disabled_capabilities` is per-client now. I guess this may be a FAQ to disable the color phantom provided by LSP-css if the user has another plugin which already does that.

![image](https://user-images.githubusercontent.com/6594915/109601825-8bf08180-7b5a-11eb-8099-f929ceb5fa76.png)

So, adding this to the settings file may be helpful in that case.