### PR TITLE
chore: update server

### DIFF
--- a/language-server/compile-language-server.sh
+++ b/language-server/compile-language-server.sh
@@ -54,11 +54,11 @@ popd || exit
 
 pushd "${SRC_DIR}" || exit
 
-npm install
+npm install --lockfile-version 2
 
 # @see https://github.com/microsoft/vscode/blob/main/extensions/package.json
-npm install typescript@^5.0.2
-npm install --include=dev @types/node
+npm install --lockfile-version 2 typescript@^5.2.0-dev.20230807
+npm install --lockfile-version 2 --include=dev @types/node
 
 popd || exit
 

--- a/language-server/css-language-features/server/out/requests.js
+++ b/language-server/css-language-features/server/out/requests.js
@@ -9,15 +9,15 @@ const vscode_languageserver_1 = require("vscode-languageserver");
 var FsContentRequest;
 (function (FsContentRequest) {
     FsContentRequest.type = new vscode_languageserver_1.RequestType('fs/content');
-})(FsContentRequest = exports.FsContentRequest || (exports.FsContentRequest = {}));
+})(FsContentRequest || (exports.FsContentRequest = FsContentRequest = {}));
 var FsStatRequest;
 (function (FsStatRequest) {
     FsStatRequest.type = new vscode_languageserver_1.RequestType('fs/stat');
-})(FsStatRequest = exports.FsStatRequest || (exports.FsStatRequest = {}));
+})(FsStatRequest || (exports.FsStatRequest = FsStatRequest = {}));
 var FsReadDirRequest;
 (function (FsReadDirRequest) {
     FsReadDirRequest.type = new vscode_languageserver_1.RequestType('fs/readDir');
-})(FsReadDirRequest = exports.FsReadDirRequest || (exports.FsReadDirRequest = {}));
+})(FsReadDirRequest || (exports.FsReadDirRequest = FsReadDirRequest = {}));
 var FileType;
 (function (FileType) {
     /**
@@ -36,7 +36,7 @@ var FileType;
      * A symbolic link to a file.
      */
     FileType[FileType["SymbolicLink"] = 64] = "SymbolicLink";
-})(FileType = exports.FileType || (exports.FileType = {}));
+})(FileType || (exports.FileType = FileType = {}));
 function getRequestService(handledSchemas, connection, runtime) {
     const builtInHandlers = {};
     for (const protocol of handledSchemas) {

--- a/language-server/package-lock.json
+++ b/language-server/package-lock.json
@@ -9,15 +9,15 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@vscode/l10n": "^0.0.11",
-        "typescript": "^5.0.2",
-        "vscode-css-languageservice": "^6.2.4",
-        "vscode-languageserver": "^8.1.0",
+        "@vscode/l10n": "^0.0.14",
+        "typescript": "^5.2.0-dev.20230807",
+        "vscode-css-languageservice": "^6.2.6",
+        "vscode-languageserver": "^8.2.0-next.1",
         "vscode-uri": "^3.0.7"
       },
       "devDependencies": {
         "@types/mocha": "^9.1.1",
-        "@types/node": "^16.18.18"
+        "@types/node": "^18.17.6"
       },
       "engines": {
         "node": "*"
@@ -30,66 +30,71 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.18.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.18.tgz",
-      "integrity": "sha512-fwGw1uvQAzabxL1pyoknPlJIF2t7+K90uTqynleKRx24n3lYcxWa3+KByLhgkF8GEAK2c7hC8Ki0RkNM5H15jQ==",
+      "version": "18.17.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.6.tgz",
+      "integrity": "sha512-fGmT/P7z7ecA6bv/ia5DlaWCH4YeZvAQMNpUhrJjtAhOhZfoxS1VLUgU2pdk63efSjQaOJWdXMuAJsws+8I6dg==",
       "dev": true
     },
     "node_modules/@vscode/l10n": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.11.tgz",
-      "integrity": "sha512-ukOMWnCg1tCvT7WnDfsUKQOFDQGsyR5tNgRpwmqi+5/vzU3ghdDXzvIM4IOPdSb3OeSsBNvmSL8nxIVOqi2WXA=="
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.14.tgz",
+      "integrity": "sha512-/yrv59IEnmh655z1oeDnGcvMYwnEzNzHLgeYcQCkhYX0xBvYWrAuefoiLcPBUkMpJsb46bqQ6Yv4pwTTQ4d3Qg=="
     },
     "node_modules/typescript": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
-      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+      "version": "5.2.0-dev.20230807",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.0-dev.20230807.tgz",
+      "integrity": "sha512-sF8sZl3r/mpAdKAxASaWaoU+mNPF3g8OrZ601HraU2l4WEwAf6nO7sq0Bzl+Y3FV7sWjy+gb6kdM1CtLjVne/g==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/vscode-css-languageservice": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.4.tgz",
-      "integrity": "sha512-9UG0s3Ss8rbaaPZL1AkGzdjrGY8F+P+Ne9snsrvD9gxltDGhsn8C2dQpqQewHrMW37OvlqJoI8sUU2AWDb+qNw==",
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.6.tgz",
+      "integrity": "sha512-SA2WkeOecIpUiEbZnjOsP/fI5CRITZEiQGSHXKiDQDwLApfKcnLhZwMtOBbIifSzESVcQa7b/shX/nbnF4NoCg==",
       "dependencies": {
-        "@vscode/l10n": "^0.0.11",
+        "@vscode/l10n": "^0.0.14",
         "vscode-languageserver-textdocument": "^1.0.8",
         "vscode-languageserver-types": "^3.17.3",
         "vscode-uri": "^3.0.7"
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
-      "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
+      "version": "8.2.0-next.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0-next.0.tgz",
+      "integrity": "sha512-13jYzaFQpTz5qQ2P+l5c/iTVsj1wUpflP0CR/v4XaEpM0oToLEXZBTcuuox1WaGIbu3Av3xxmGNU4Hydl1iNKg==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageserver": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.1.0.tgz",
-      "integrity": "sha512-eUt8f1z2N2IEUDBsKaNapkz7jl5QpskN2Y0G01T/ItMxBxw1fJwvtySGB9QMecatne8jFIWJGWI61dWjyTLQsw==",
+      "version": "8.2.0-next.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.2.0-next.1.tgz",
+      "integrity": "sha512-994AXMKBijzjlnpf8p9M+ntsNJDjR8pr55NJPYxKjy/nUhVkg962dAomelH6Z94401kBZmSbfP/K/20cB54aFA==",
       "dependencies": {
-        "vscode-languageserver-protocol": "3.17.3"
+        "vscode-languageserver-protocol": "3.17.4-next.1"
       },
       "bin": {
         "installServerIntoExtension": "bin/installServerIntoExtension"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
-      "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+      "version": "3.17.4-next.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.4-next.1.tgz",
+      "integrity": "sha512-qrK4BycgPR/+nkRN9PRVTblkLp+kUPUmAgF6rDhFzZIPXW4/MqWwFUT8uswIMGdlTPPgCEkFO/AYEZK1fDXODg==",
       "dependencies": {
-        "vscode-jsonrpc": "8.1.0",
-        "vscode-languageserver-types": "3.17.3"
+        "vscode-jsonrpc": "8.2.0-next.0",
+        "vscode-languageserver-types": "3.17.4-next.0"
       }
+    },
+    "node_modules/vscode-languageserver-protocol/node_modules/vscode-languageserver-types": {
+      "version": "3.17.4-next.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.4-next.0.tgz",
+      "integrity": "sha512-2FPKboHnT04xYjfM8JpJVBz4a/tryMw58jmzucaabZMZN5hzoFBrhc97jNG4n6edr9JUb9+QSwwcAcYpDTAoag=="
     },
     "node_modules/vscode-languageserver-textdocument": {
       "version": "1.0.8",
@@ -115,52 +120,59 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.18.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.18.tgz",
-      "integrity": "sha512-fwGw1uvQAzabxL1pyoknPlJIF2t7+K90uTqynleKRx24n3lYcxWa3+KByLhgkF8GEAK2c7hC8Ki0RkNM5H15jQ==",
+      "version": "18.17.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.6.tgz",
+      "integrity": "sha512-fGmT/P7z7ecA6bv/ia5DlaWCH4YeZvAQMNpUhrJjtAhOhZfoxS1VLUgU2pdk63efSjQaOJWdXMuAJsws+8I6dg==",
       "dev": true
     },
     "@vscode/l10n": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.11.tgz",
-      "integrity": "sha512-ukOMWnCg1tCvT7WnDfsUKQOFDQGsyR5tNgRpwmqi+5/vzU3ghdDXzvIM4IOPdSb3OeSsBNvmSL8nxIVOqi2WXA=="
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.14.tgz",
+      "integrity": "sha512-/yrv59IEnmh655z1oeDnGcvMYwnEzNzHLgeYcQCkhYX0xBvYWrAuefoiLcPBUkMpJsb46bqQ6Yv4pwTTQ4d3Qg=="
     },
     "typescript": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
-      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw=="
+      "version": "5.2.0-dev.20230807",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.0-dev.20230807.tgz",
+      "integrity": "sha512-sF8sZl3r/mpAdKAxASaWaoU+mNPF3g8OrZ601HraU2l4WEwAf6nO7sq0Bzl+Y3FV7sWjy+gb6kdM1CtLjVne/g=="
     },
     "vscode-css-languageservice": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.4.tgz",
-      "integrity": "sha512-9UG0s3Ss8rbaaPZL1AkGzdjrGY8F+P+Ne9snsrvD9gxltDGhsn8C2dQpqQewHrMW37OvlqJoI8sUU2AWDb+qNw==",
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.6.tgz",
+      "integrity": "sha512-SA2WkeOecIpUiEbZnjOsP/fI5CRITZEiQGSHXKiDQDwLApfKcnLhZwMtOBbIifSzESVcQa7b/shX/nbnF4NoCg==",
       "requires": {
-        "@vscode/l10n": "^0.0.11",
+        "@vscode/l10n": "^0.0.14",
         "vscode-languageserver-textdocument": "^1.0.8",
         "vscode-languageserver-types": "^3.17.3",
         "vscode-uri": "^3.0.7"
       }
     },
     "vscode-jsonrpc": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
-      "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw=="
+      "version": "8.2.0-next.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0-next.0.tgz",
+      "integrity": "sha512-13jYzaFQpTz5qQ2P+l5c/iTVsj1wUpflP0CR/v4XaEpM0oToLEXZBTcuuox1WaGIbu3Av3xxmGNU4Hydl1iNKg=="
     },
     "vscode-languageserver": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.1.0.tgz",
-      "integrity": "sha512-eUt8f1z2N2IEUDBsKaNapkz7jl5QpskN2Y0G01T/ItMxBxw1fJwvtySGB9QMecatne8jFIWJGWI61dWjyTLQsw==",
+      "version": "8.2.0-next.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.2.0-next.1.tgz",
+      "integrity": "sha512-994AXMKBijzjlnpf8p9M+ntsNJDjR8pr55NJPYxKjy/nUhVkg962dAomelH6Z94401kBZmSbfP/K/20cB54aFA==",
       "requires": {
-        "vscode-languageserver-protocol": "3.17.3"
+        "vscode-languageserver-protocol": "3.17.4-next.1"
       }
     },
     "vscode-languageserver-protocol": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
-      "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+      "version": "3.17.4-next.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.4-next.1.tgz",
+      "integrity": "sha512-qrK4BycgPR/+nkRN9PRVTblkLp+kUPUmAgF6rDhFzZIPXW4/MqWwFUT8uswIMGdlTPPgCEkFO/AYEZK1fDXODg==",
       "requires": {
-        "vscode-jsonrpc": "8.1.0",
-        "vscode-languageserver-types": "3.17.3"
+        "vscode-jsonrpc": "8.2.0-next.0",
+        "vscode-languageserver-types": "3.17.4-next.0"
+      },
+      "dependencies": {
+        "vscode-languageserver-types": {
+          "version": "3.17.4-next.0",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.4-next.0.tgz",
+          "integrity": "sha512-2FPKboHnT04xYjfM8JpJVBz4a/tryMw58jmzucaabZMZN5hzoFBrhc97jNG4n6edr9JUb9+QSwwcAcYpDTAoag=="
+        }
       }
     },
     "vscode-languageserver-textdocument": {

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -10,15 +10,15 @@
   "main": "./out/node/cssServerMain",
   "browser": "./dist/browser/cssServerMain",
   "dependencies": {
-    "@vscode/l10n": "^0.0.11",
-    "typescript": "^5.0.2",
-    "vscode-css-languageservice": "^6.2.4",
-    "vscode-languageserver": "^8.1.0",
+    "@vscode/l10n": "^0.0.14",
+    "typescript": "^5.2.0-dev.20230807",
+    "vscode-css-languageservice": "^6.2.6",
+    "vscode-languageserver": "^8.2.0-next.1",
     "vscode-uri": "^3.0.7"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",
-    "@types/node": "^16.18.18"
+    "@types/node": "^18.17.6"
   },
   "scripts": {
     "compile": "gulp compile-extension:css-language-features-server",

--- a/language-server/update-info.log
+++ b/language-server/update-info.log
@@ -1,2 +1,2 @@
 Archive:  src-main.zip
-13e6f5f007215ffe9efc814ce42f720f1ff24041
+df7e41cc5ae63ac4f74258ba098deb070acf5ac1


### PR DESCRIPTION
As a note, `npm install` generates the lockfile in v3 format with my npm v9.6.7. `yarn` failed to convert v3 npm lockfile into a yarn lockfile. So I added `--lockfile-version 2` flag to force v2 npm lockfile generation.