### PR TITLE
fix: make compile script work with new code

### DIFF
--- a/language-server/compile-language-server.sh
+++ b/language-server/compile-language-server.sh
@@ -57,8 +57,8 @@ pushd "${SRC_DIR}" || exit
 npm install --lockfile-version 2
 
 # @see https://github.com/microsoft/vscode/blob/main/extensions/package.json
-npm install --lockfile-version 2 typescript@^5.2.0-dev.20230807
-npm install --lockfile-version 2 --include=dev @types/node
+ts_version="$( jq '.dependencies.typescript' --raw-output "${REPO_DIR}/${GITHUB_REPO_NAME}/extensions/package.json" )"
+npm install -D --lockfile-version 2 typescript@${ts_version}
 
 popd || exit
 

--- a/language-server/package-lock.json
+++ b/language-server/package-lock.json
@@ -9,15 +9,15 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@vscode/l10n": "^0.0.14",
-        "typescript": "^5.2.0-dev.20230807",
-        "vscode-css-languageservice": "^6.2.6",
-        "vscode-languageserver": "^8.2.0-next.1",
-        "vscode-uri": "^3.0.7"
+        "@vscode/l10n": "^0.0.16",
+        "vscode-css-languageservice": "^6.2.11",
+        "vscode-languageserver": "^9.0.1",
+        "vscode-uri": "^3.0.8"
       },
       "devDependencies": {
         "@types/mocha": "^9.1.1",
-        "@types/node": "^18.17.6"
+        "@types/node": "18.x",
+        "typescript": "^5.3.2"
       },
       "engines": {
         "node": "*"
@@ -30,20 +30,21 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.17.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.6.tgz",
-      "integrity": "sha512-fGmT/P7z7ecA6bv/ia5DlaWCH4YeZvAQMNpUhrJjtAhOhZfoxS1VLUgU2pdk63efSjQaOJWdXMuAJsws+8I6dg==",
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
       "dev": true
     },
     "node_modules/@vscode/l10n": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.14.tgz",
-      "integrity": "sha512-/yrv59IEnmh655z1oeDnGcvMYwnEzNzHLgeYcQCkhYX0xBvYWrAuefoiLcPBUkMpJsb46bqQ6Yv4pwTTQ4d3Qg=="
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.16.tgz",
+      "integrity": "sha512-JT5CvrIYYCrmB+dCana8sUqJEcGB1ZDXNLMQ2+42bW995WmNoenijWMUdZfwmuQUTQcEVVIa2OecZzTYWUW9Cg=="
     },
     "node_modules/typescript": {
-      "version": "5.2.0-dev.20230807",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.0-dev.20230807.tgz",
-      "integrity": "sha512-sF8sZl3r/mpAdKAxASaWaoU+mNPF3g8OrZ601HraU2l4WEwAf6nO7sq0Bzl+Y3FV7sWjy+gb6kdM1CtLjVne/g==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -53,63 +54,58 @@
       }
     },
     "node_modules/vscode-css-languageservice": {
-      "version": "6.2.6",
-      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.6.tgz",
-      "integrity": "sha512-SA2WkeOecIpUiEbZnjOsP/fI5CRITZEiQGSHXKiDQDwLApfKcnLhZwMtOBbIifSzESVcQa7b/shX/nbnF4NoCg==",
+      "version": "6.2.11",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.11.tgz",
+      "integrity": "sha512-qn49Wa6K94LnizpVxmlYrcPf1Cb36gq1nNueW0COhi4shylXBzET5wuDbH8ZWQlJD0HM5Mmnn7WE9vQVVs+ULA==",
       "dependencies": {
-        "@vscode/l10n": "^0.0.14",
-        "vscode-languageserver-textdocument": "^1.0.8",
-        "vscode-languageserver-types": "^3.17.3",
-        "vscode-uri": "^3.0.7"
+        "@vscode/l10n": "^0.0.16",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-languageserver-types": "3.17.5",
+        "vscode-uri": "^3.0.8"
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0-next.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0-next.0.tgz",
-      "integrity": "sha512-13jYzaFQpTz5qQ2P+l5c/iTVsj1wUpflP0CR/v4XaEpM0oToLEXZBTcuuox1WaGIbu3Av3xxmGNU4Hydl1iNKg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageserver": {
-      "version": "8.2.0-next.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.2.0-next.1.tgz",
-      "integrity": "sha512-994AXMKBijzjlnpf8p9M+ntsNJDjR8pr55NJPYxKjy/nUhVkg962dAomelH6Z94401kBZmSbfP/K/20cB54aFA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
       "dependencies": {
-        "vscode-languageserver-protocol": "3.17.4-next.1"
+        "vscode-languageserver-protocol": "3.17.5"
       },
       "bin": {
         "installServerIntoExtension": "bin/installServerIntoExtension"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.4-next.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.4-next.1.tgz",
-      "integrity": "sha512-qrK4BycgPR/+nkRN9PRVTblkLp+kUPUmAgF6rDhFzZIPXW4/MqWwFUT8uswIMGdlTPPgCEkFO/AYEZK1fDXODg==",
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
       "dependencies": {
-        "vscode-jsonrpc": "8.2.0-next.0",
-        "vscode-languageserver-types": "3.17.4-next.0"
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
       }
     },
-    "node_modules/vscode-languageserver-protocol/node_modules/vscode-languageserver-types": {
-      "version": "3.17.4-next.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.4-next.0.tgz",
-      "integrity": "sha512-2FPKboHnT04xYjfM8JpJVBz4a/tryMw58jmzucaabZMZN5hzoFBrhc97jNG4n6edr9JUb9+QSwwcAcYpDTAoag=="
-    },
     "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
-      "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
+      "integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA=="
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
-      "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
     },
     "node_modules/vscode-uri": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
-      "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA=="
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+      "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="
     }
   },
   "dependencies": {
@@ -120,75 +116,69 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.17.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.6.tgz",
-      "integrity": "sha512-fGmT/P7z7ecA6bv/ia5DlaWCH4YeZvAQMNpUhrJjtAhOhZfoxS1VLUgU2pdk63efSjQaOJWdXMuAJsws+8I6dg==",
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
       "dev": true
     },
     "@vscode/l10n": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.14.tgz",
-      "integrity": "sha512-/yrv59IEnmh655z1oeDnGcvMYwnEzNzHLgeYcQCkhYX0xBvYWrAuefoiLcPBUkMpJsb46bqQ6Yv4pwTTQ4d3Qg=="
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.16.tgz",
+      "integrity": "sha512-JT5CvrIYYCrmB+dCana8sUqJEcGB1ZDXNLMQ2+42bW995WmNoenijWMUdZfwmuQUTQcEVVIa2OecZzTYWUW9Cg=="
     },
     "typescript": {
-      "version": "5.2.0-dev.20230807",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.0-dev.20230807.tgz",
-      "integrity": "sha512-sF8sZl3r/mpAdKAxASaWaoU+mNPF3g8OrZ601HraU2l4WEwAf6nO7sq0Bzl+Y3FV7sWjy+gb6kdM1CtLjVne/g=="
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+      "dev": true
     },
     "vscode-css-languageservice": {
-      "version": "6.2.6",
-      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.6.tgz",
-      "integrity": "sha512-SA2WkeOecIpUiEbZnjOsP/fI5CRITZEiQGSHXKiDQDwLApfKcnLhZwMtOBbIifSzESVcQa7b/shX/nbnF4NoCg==",
+      "version": "6.2.11",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.11.tgz",
+      "integrity": "sha512-qn49Wa6K94LnizpVxmlYrcPf1Cb36gq1nNueW0COhi4shylXBzET5wuDbH8ZWQlJD0HM5Mmnn7WE9vQVVs+ULA==",
       "requires": {
-        "@vscode/l10n": "^0.0.14",
-        "vscode-languageserver-textdocument": "^1.0.8",
-        "vscode-languageserver-types": "^3.17.3",
-        "vscode-uri": "^3.0.7"
+        "@vscode/l10n": "^0.0.16",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-languageserver-types": "3.17.5",
+        "vscode-uri": "^3.0.8"
       }
     },
     "vscode-jsonrpc": {
-      "version": "8.2.0-next.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0-next.0.tgz",
-      "integrity": "sha512-13jYzaFQpTz5qQ2P+l5c/iTVsj1wUpflP0CR/v4XaEpM0oToLEXZBTcuuox1WaGIbu3Av3xxmGNU4Hydl1iNKg=="
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="
     },
     "vscode-languageserver": {
-      "version": "8.2.0-next.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.2.0-next.1.tgz",
-      "integrity": "sha512-994AXMKBijzjlnpf8p9M+ntsNJDjR8pr55NJPYxKjy/nUhVkg962dAomelH6Z94401kBZmSbfP/K/20cB54aFA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
       "requires": {
-        "vscode-languageserver-protocol": "3.17.4-next.1"
+        "vscode-languageserver-protocol": "3.17.5"
       }
     },
     "vscode-languageserver-protocol": {
-      "version": "3.17.4-next.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.4-next.1.tgz",
-      "integrity": "sha512-qrK4BycgPR/+nkRN9PRVTblkLp+kUPUmAgF6rDhFzZIPXW4/MqWwFUT8uswIMGdlTPPgCEkFO/AYEZK1fDXODg==",
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
       "requires": {
-        "vscode-jsonrpc": "8.2.0-next.0",
-        "vscode-languageserver-types": "3.17.4-next.0"
-      },
-      "dependencies": {
-        "vscode-languageserver-types": {
-          "version": "3.17.4-next.0",
-          "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.4-next.0.tgz",
-          "integrity": "sha512-2FPKboHnT04xYjfM8JpJVBz4a/tryMw58jmzucaabZMZN5hzoFBrhc97jNG4n6edr9JUb9+QSwwcAcYpDTAoag=="
-        }
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
       }
     },
     "vscode-languageserver-textdocument": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
-      "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
+      "integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA=="
     },
     "vscode-languageserver-types": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
-      "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
     },
     "vscode-uri": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
-      "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA=="
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+      "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="
     }
   }
 }

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -10,15 +10,15 @@
   "main": "./out/node/cssServerMain",
   "browser": "./dist/browser/cssServerMain",
   "dependencies": {
-    "@vscode/l10n": "^0.0.14",
-    "typescript": "^5.2.0-dev.20230807",
-    "vscode-css-languageservice": "^6.2.6",
-    "vscode-languageserver": "^8.2.0-next.1",
-    "vscode-uri": "^3.0.7"
+    "@vscode/l10n": "^0.0.16",
+    "vscode-css-languageservice": "^6.2.11",
+    "vscode-languageserver": "^9.0.1",
+    "vscode-uri": "^3.0.8"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",
-    "@types/node": "^18.17.6"
+    "@types/node": "18.x",
+    "typescript": "^5.3.2"
   },
   "scripts": {
     "compile": "gulp compile-extension:css-language-features-server",

--- a/language-server/update-info.log
+++ b/language-server/update-info.log
@@ -1,2 +1,2 @@
-Archive:  src-main.zip
-df7e41cc5ae63ac4f74258ba098deb070acf5ac1
+Archive:  src-1.85.1.zip
+0ee08df0cf4527e40edc9aa28f4b5bd38bbff2b2


### PR DESCRIPTION
Fixes #47

Latest vscode tag doesn't have any new changes to css-language-features.

I've moved typescript dep back to devDependencies because I don't see it being used anywhere. I remember we went back and forth with that before because it caused issues but not sure if that was in this server...